### PR TITLE
Screenshots + dependency update

### DIFF
--- a/BackEnd/swagger_server/services/db_service.py
+++ b/BackEnd/swagger_server/services/db_service.py
@@ -36,11 +36,11 @@ class DatabaseConn:
 
 
         """
-        self.engine = sqla.create_engine('mysql+pymysql://pybroker:mSWcwbTpuTv4Liwb@pma.tutorialfactory.org/pybroker',
+        self.engine = sqla.create_engine('<INSERT_DB_CONNECTION_STRING>',
                                          echo=False, pool_size=5, pool_recycle=3600)
 
     def insert_user(self, user: User) -> bool:
-        """
+        """ 
 
             desc: insert User into Database Function. Called after registering
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ Project End: 22.11.2020
 ### Dark Mode Ready
 <img width="1788" alt="Screenshot 2021-12-29 at 13 46 12" src="https://user-images.githubusercontent.com/62757957/147664203-9744ad3e-5e24-4fdd-b00d-b979019699ce.png">
 
+## Architecture / Infrastructure
+![Uberblick_der_AnwendungsarchitekturPRESET](https://user-images.githubusercontent.com/62757957/147664785-f0758d24-0dc3-43ee-9b5f-f0791451d412.png)
 
 ## Requirements
 Python: 3.8

--- a/README.md
+++ b/README.md
@@ -8,6 +8,20 @@ Authors: Daniel Ebert, Luca Müller, Luca Weissbeck, Ben Schaper, Jannik Sinz
 Project Start: 24.10.2020  
 Project End: 22.11.2020  
 
+## Preview
+### Buying Stocks 
+![screencapture-localhost-8501-2021-12-29-13_42_59](https://user-images.githubusercontent.com/62757957/147664009-a6490873-d65c-4911-84d1-3b5d83cf80fc.png)
+### Selling Stocks
+![screencapture-localhost-8501-2021-12-29-13_44_14](https://user-images.githubusercontent.com/62757957/147664079-914c3782-3c55-4d2e-b9c8-7c68cebb0e0e.png)
+### Stock Screener
+![screencapture-localhost-8501-2021-12-29-13_41_58](https://user-images.githubusercontent.com/62757957/147664103-9eaf8f82-0556-4d4d-b57b-c694d61eebef.png)
+### Settings
+![screencapture-localhost-8501-2021-12-29-13_43_21](https://user-images.githubusercontent.com/62757957/147664290-5f46e4ff-da9b-4896-9572-8589f0e7ec60.png)
+
+### Dark Mode Ready
+<img width="1788" alt="Screenshot 2021-12-29 at 13 46 12" src="https://user-images.githubusercontent.com/62757957/147664203-9744ad3e-5e24-4fdd-b00d-b979019699ce.png">
+
+
 ## Requirements
 Python: 3.8
 ### with pip:

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ python-dateutil>=2.8.1
 requests>=2.24.0
 html5lib == 1.1
 APScheduler == 3.6.3
-pandas-market-calendars == 1.6.1
+pandas-market-calendars == 3.1
 streamlit == 0.70.0
 streamlit-echarts == 0.1.0
 requests == 2.24.0


### PR DESCRIPTION
# This PR includes 
## Screenshots
- broker (buy/sell)
- stock screener
- settings
- dark mode preview

## Architecture Diagram
- screenshot of architecture diagram

## Dependency Update
- pandas-market-calendars 1.6.1 --> 3.1
1.6.1 impeded the start of backend. See https://stackoverflow.com/questions/68249890/np-nat-error-when-attempting-to-import-pandas-market-calender for more information. 

## To Do:
- Include screenshot of portfolio page (needs to collect data first over the following days)
